### PR TITLE
postgres: Use PG version of the selected instance

### DIFF
--- a/postgresql_statistics.json
+++ b/postgresql_statistics.json
@@ -131,7 +131,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "pg_static",
+          "expr": "pg_static{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{short_version}}",
@@ -774,7 +774,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "pg_settings_seq_page_cost",
+          "expr": "pg_settings_seq_page_cost{instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"


### PR DESCRIPTION
This commit makes sure that the PG version and seq page cost displayed are the ones from the selected instance.

Thank you for the great dashboard btw!